### PR TITLE
fixed containers names in displayLogs.sh

### DIFF
--- a/common/scripts/displayLogs.sh
+++ b/common/scripts/displayLogs.sh
@@ -10,10 +10,10 @@ then
     echo "Logs for $CONTAINER in docker"
     case $CONTAINER in 
     runtime) 
-        docker logs nussknacker_jobmanager
+        docker logs `docker ps -q -f name=jobmanager`  # if used in swarm, container names have some random stuff appended 
         ;;
     *)
-        docker logs nussknacker_$CONTAINER
+        docker logs `docker ps -q -f name=designer`
         ;;
     esac    
 else


### PR DESCRIPTION
If used from within swarm cluster, displayLogs.sh script will not work, as container names have suffixes added by swarm and `docker ps nussknacker_jobmanager` does not work