### PR TITLE
[NU-1286] tests: schema caching fix

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -106,7 +106,7 @@ jobs:
         run: COMMAND=template ./k8s-helm/install-streaming.sh
       - name: install quickstart
         shell: bash
-        run: ./k8s-helm/install-streaming.sh --debug
+        run: NUSSKNACKER_SCHEMAS_CACHE_TTL=0s ./k8s-helm/install-streaming.sh --debug
       - name: Test quickstart
         shell: bash
         run: ./common/tests/testK8sStreaming.sh

--- a/k8s-helm/install-common.sh
+++ b/k8s-helm/install-common.sh
@@ -35,4 +35,5 @@ helm $COMMAND $DEVEL_ARG "${RELEASE}" $HELM_REPO \
   $ADDITIONAL_VALS \
   --set image.tag="${NUSSKNACKER_VERSION}" \
   --set nussknacker.usageStatisticsReportsFingerprint="${USAGE_REPORTS_FINGERPRINT}" \
-  --set postgresql.auth.existingSecret="${RELEASE}-postgresql" $@
+  --set postgresql.auth.existingSecret="${RELEASE}-postgresql" \
+  --set kafka.schemaRegistryCacheConfig.availableSchemasExpirationTime="${NUSSKNACKER_SCHEMAS_CACHE_TTL:-10s}" $@

--- a/k8s-helm/values-streaming.yaml
+++ b/k8s-helm/values-streaming.yaml
@@ -27,6 +27,9 @@ nussknacker:
       openAPI:
         url: "http://customer-service/swagger"
         rootUrl: "http://customer-service"
+    kafka:
+      schemaRegistryCacheConfig:
+        availableSchemasExpirationTime: "{{ .Values.kafka.schemaRegistryCacheConfig.availableSchemasExpirationTime }}"
   usageStatisticsReportsSource: "quickstart-helmchart"
 
 persistence: 


### PR DESCRIPTION
`helm-k8s-streaming-test` failed because the empty list of schemas was cached and the schemas added before the test execution were not taken into consideration during testing. The scenario was classified as invalid because there was no schema for Kafka's topic used in the scenario. 