### PR TITLE
[FIX] printing logs on error 

### DIFF
--- a/common/tests/testDockerStreaming.sh
+++ b/common/tests/testDockerStreaming.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")"
 
 displayLogs() {
-    export BASE_PATH=$(pwd)
+    export BASE_PATH="$(fullPath ../../docker/streaming)"
     ../../docker/common/displayAllDockerLogs.sh 
 }
 


### PR DESCRIPTION
In docker-based quickstart, there was a problem with printing docker logs when some error occurred during quickstart testing.