### PR TITLE
get rid of "WARN: InvalidDefaultArgInFrom: Default value 

### DIFF
--- a/flink/Dockerfile
+++ b/flink/Dockerfile
@@ -1,4 +1,4 @@
-ARG FLINK_VERSION
+ARG FLINK_VERSION=undefined-flink-version
 
 FROM flink:${FLINK_VERSION}
 


### PR DESCRIPTION
get rid of "WARN: InvalidDefaultArgInFrom: Default value for ARG flink:${FLINK_VERSION} results in empty or invalid base image name (line 3)"